### PR TITLE
Added required option to the required flags

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -26,7 +26,7 @@ var applicationDeleteURL = "/v1/applications/%s" //applicationDelete
 var applicationCmd = &cobra.Command{
 	Use:     "application",
 	Aliases: []string{"a"},
-	Short:   "commands related to applications",
+	Short:   "Commands related to applications",
 	Long:    `This is the command related to applications`,
 }
 

--- a/cmd/application_delete.go
+++ b/cmd/application_delete.go
@@ -33,14 +33,14 @@ var (
 var applicationDeleteCmd = &cobra.Command{
 	Use:     "delete",
 	Aliases: []string{"d"},
-	Short:   "Remove an application",
-	Long:    `remove an application from axonserver`,
+	Short:   "Deletes the application",
+	Long:    `Deletes the application from Axon Server. Applications will no longer be able to connect to Axon Server using this token.`,
 	Run:     deleteApplication,
 }
 
 func init() {
 	applicationCmd.AddCommand(applicationDeleteCmd)
-	applicationDeleteCmd.Flags().StringVarP(&applicationDelete, "application", "a", "", "Name of the application")
+	applicationDeleteCmd.Flags().StringVarP(&applicationDelete, "application", "a", "", "*Name of the application")
 	// required flags
 	applicationDeleteCmd.MarkFlagRequired("application")
 }

--- a/cmd/application_delete.go
+++ b/cmd/application_delete.go
@@ -41,6 +41,8 @@ var applicationDeleteCmd = &cobra.Command{
 func init() {
 	applicationCmd.AddCommand(applicationDeleteCmd)
 	applicationDeleteCmd.Flags().StringVarP(&applicationDelete, "application", "a", "", "Name of the application")
+	// required flags
+	applicationDeleteCmd.MarkFlagRequired("application")
 }
 
 func deleteApplication(cmd *cobra.Command, args []string) {

--- a/cmd/application_list.go
+++ b/cmd/application_list.go
@@ -28,8 +28,8 @@ import (
 var applicationListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"l"},
-	Short:   "list all the applications",
-	Long:    `use to list all the applications on the server`,
+	Short:   "List all applications",
+	Long:    `Lists all applications and the roles per application per context.`,
 	Run:     listApplications,
 }
 

--- a/cmd/application_register.go
+++ b/cmd/application_register.go
@@ -57,6 +57,8 @@ func init() {
 	applicationRegisterCmd.Flags().StringVarP(&applicationName, "name", "a", "", "application name")
 	applicationRegisterCmd.Flags().StringVarP(&applicationDescription, "description", "d", "", "application description")
 	applicationRegisterCmd.Flags().StringSliceVarP(&applicationRoles, "roles", "r", []string{}, "application roles. Please write them as comma separated values, and separate the context and role with an @ sign. Example: ROLE1@CONTEXT,ROLE2@CONTEXT,...")
+	// required flags
+	applicationRegisterCmd.MarkFlagRequired("name")
 }
 
 func registerApplication(cmd *cobra.Command, args []string) {

--- a/cmd/application_register.go
+++ b/cmd/application_register.go
@@ -47,16 +47,17 @@ var applicationRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Aliases: []string{"r"},
 	Short: "Register an application",
-	Long: `use to register an application on the server`,
+	Long: `Registers an application with specified name. Roles is a comma seperated list of roles per context, where a role per context is the combination of @, e.g. READ@context1,WRITE@context2. If you do not specify the context for the role it will be for context default.
+	If you omit the -T option, Axon Server will generate a unique token for you. Applications must use this token to access Axon Server. Note that this token is only returned once, you will not be able to retrieve this token later.`,
 	Run: registerApplication,
 }
 
 func init() {
 	applicationCmd.AddCommand(applicationRegisterCmd)
 
-	applicationRegisterCmd.Flags().StringVarP(&applicationName, "name", "a", "", "application name")
-	applicationRegisterCmd.Flags().StringVarP(&applicationDescription, "description", "d", "", "application description")
-	applicationRegisterCmd.Flags().StringSliceVarP(&applicationRoles, "roles", "r", []string{}, "application roles. Please write them as comma separated values, and separate the context and role with an @ sign. Example: ROLE1@CONTEXT,ROLE2@CONTEXT,...")
+	applicationRegisterCmd.Flags().StringVarP(&applicationName, "name", "a", "", "*Name of the application")
+	applicationRegisterCmd.Flags().StringVarP(&applicationDescription, "description", "d", "", "[Optional] Description of the application")
+	applicationRegisterCmd.Flags().StringSliceVarP(&applicationRoles, "roles", "r", []string{}, "Roles for the application, use role@context")
 	// required flags
 	applicationRegisterCmd.MarkFlagRequired("name")
 }

--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -28,7 +28,7 @@ import (
 var clusterListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"l"},
-	Short:   "list all clusters",
+	Short:   "List all clusters",
 	Long:    `Shows all the nodes in the cluster, including their hostnames, http ports and grpc ports.`,
 	Run:     listClusters,
 }

--- a/cmd/cluster_node_register.go
+++ b/cmd/cluster_node_register.go
@@ -44,7 +44,7 @@ type clusterNode struct {
 var clusterRegisterNodeCmd = &cobra.Command{
 	Use:     "register",
 	Aliases: []string{"r"},
-	Short:   "register a node to the clusters",
+	Short:   "Register a node to the cluster",
 	Long: `Tells this Axon Server node to join a cluster. You need to specify the hostname and optionally the internal port number of a node that is the leader of the _admin context. If you do not specify the internal port number it uses 8224 (default internal port number for Axon Server).
 	If you specify a context, the new node will be a member of the specified context. If you haven't specified a context, the new node will become a member of all the contexts which the _admin leader is a part of.`,
 	Run: registerNodeToCluster,
@@ -53,8 +53,8 @@ var clusterRegisterNodeCmd = &cobra.Command{
 func init() {
 	clusterCmd.AddCommand(clusterRegisterNodeCmd)
 	// flags
-	clusterRegisterNodeCmd.Flags().StringVarP(&internalHost, "internal-host", "i", "", "Internal hostname of the node")
-	clusterRegisterNodeCmd.Flags().StringVarP(&internalPort, "internal-port", "p", "8224", "Internal port of the node (default 8224)")
+	clusterRegisterNodeCmd.Flags().StringVarP(&internalHost, "internal-host", "i", "", "*Internal hostname of the node")
+	clusterRegisterNodeCmd.Flags().StringVarP(&internalPort, "internal-port", "p", "8224", "Internal port of the node")
 	clusterRegisterNodeCmd.Flags().StringVarP(&contextToRegister, "context", "c", "", "[Optional - Enterprise Edition only] context to register node in")
 	clusterRegisterNodeCmd.Flags().BoolVarP(&noContext, "no-contexts", "", false, "[Optional - Enterprise Edition only] add node to cluster, but don't register it in any contexts")
 	// required flags

--- a/cmd/cluster_node_register.go
+++ b/cmd/cluster_node_register.go
@@ -57,6 +57,8 @@ func init() {
 	clusterRegisterNodeCmd.Flags().StringVarP(&internalPort, "internal-port", "p", "8224", "Internal port of the node (default 8224)")
 	clusterRegisterNodeCmd.Flags().StringVarP(&contextToRegister, "context", "c", "", "[Optional - Enterprise Edition only] context to register node in")
 	clusterRegisterNodeCmd.Flags().BoolVarP(&noContext, "no-contexts", "", false, "[Optional - Enterprise Edition only] add node to cluster, but don't register it in any contexts")
+	// required flags
+	clusterRegisterNodeCmd.MarkFlagRequired("internal-host")
 }
 
 func registerNodeToCluster(cmd *cobra.Command, args []string) {
@@ -67,7 +69,7 @@ func registerNodeToCluster(cmd *cobra.Command, args []string) {
 
 	log.Println("calling: " + viper.GetString("server") + clusterRegisterNodeURL)
 	clusterNodeJson := buildClusterNodeJson()
-	req, err := http.NewRequest("POST", viper.GetString("server")+clusterRegisterNodeURL, bytes.NewBuffer(clusterNodeJson))
+	req, err := http.NewRequest("ur", viper.GetString("server")+clusterRegisterNodeURL, bytes.NewBuffer(clusterNodeJson))
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}

--- a/cmd/cluster_node_register.go
+++ b/cmd/cluster_node_register.go
@@ -69,7 +69,7 @@ func registerNodeToCluster(cmd *cobra.Command, args []string) {
 
 	log.Println("calling: " + viper.GetString("server") + clusterRegisterNodeURL)
 	clusterNodeJson := buildClusterNodeJson()
-	req, err := http.NewRequest("ur", viper.GetString("server")+clusterRegisterNodeURL, bytes.NewBuffer(clusterNodeJson))
+	req, err := http.NewRequest("POST", viper.GetString("server")+clusterRegisterNodeURL, bytes.NewBuffer(clusterNodeJson))
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}

--- a/cmd/cluster_node_unregister.go
+++ b/cmd/cluster_node_unregister.go
@@ -32,7 +32,7 @@ var (
 var clusterUnregisterNodeCmd = &cobra.Command{
 	Use:     "unregister",
 	Aliases: []string{"u"},
-	Short:   "unregister a node to the clusters",
+	Short:   "Unregister a node from the cluster",
 	Long:    `Removes the node with specified name from the cluster. After this, the node that is deleted will still be running in standalone mode`,
 	Run:     unregisterNodeToCluster,
 }
@@ -40,7 +40,7 @@ var clusterUnregisterNodeCmd = &cobra.Command{
 func init() {
 	clusterCmd.AddCommand(clusterUnregisterNodeCmd)
 	// flags
-	clusterUnregisterNodeCmd.Flags().StringVarP(&nodename, "node", "n", "", "Name of the node")
+	clusterUnregisterNodeCmd.Flags().StringVarP(&nodename, "node", "n", "", "*Name of the node")
 	// required flags
 	clusterUnregisterNodeCmd.MarkFlagRequired("node")
 }

--- a/cmd/cluster_node_unregister.go
+++ b/cmd/cluster_node_unregister.go
@@ -41,6 +41,8 @@ func init() {
 	clusterCmd.AddCommand(clusterUnregisterNodeCmd)
 	// flags
 	clusterUnregisterNodeCmd.Flags().StringVarP(&nodename, "node", "n", "", "Name of the node")
+	// required flags
+	clusterUnregisterNodeCmd.MarkFlagRequired("node")
 }
 
 func unregisterNodeToCluster(cmd *cobra.Command, args []string) {

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -26,7 +26,7 @@ var contextDeleteURL = "/v1/context/%s" //contextDelete
 var contextCmd = &cobra.Command{
 	Use:     "context",
 	Aliases: []string{"c"},
-	Short:   "commands related to contexts",
+	Short:   "Commands related to contexts",
 	Long:    `This is the command related to contexts`,
 }
 

--- a/cmd/context_delete.go
+++ b/cmd/context_delete.go
@@ -33,14 +33,14 @@ var (
 var contextDeleteCmd = &cobra.Command{
 	Use:     "delete",
 	Aliases: []string{"d"},
-	Short:   "Remove a context",
-	Long:    `remove a context from axonserver`,
+	Short:   "Deletes the context.",
+	Long:    `Deletes the context from axonserver.`,
 	Run:     deleteContext,
 }
 
 func init() {
 	contextCmd.AddCommand(contextDeleteCmd)
-	contextDeleteCmd.Flags().StringVarP(&contextDelete, "context", "c", "", "Name of the context")
+	contextDeleteCmd.Flags().StringVarP(&contextDelete, "context", "c", "", "*Name of the context")
 	// required flags
 	contextDeleteCmd.MarkFlagRequired("context")
 }

--- a/cmd/context_delete.go
+++ b/cmd/context_delete.go
@@ -41,6 +41,8 @@ var contextDeleteCmd = &cobra.Command{
 func init() {
 	contextCmd.AddCommand(contextDeleteCmd)
 	contextDeleteCmd.Flags().StringVarP(&contextDelete, "context", "c", "", "Name of the context")
+	// required flags
+	contextDeleteCmd.MarkFlagRequired("context")
 }
 
 func deleteContext(cmd *cobra.Command, args []string) {

--- a/cmd/context_list.go
+++ b/cmd/context_list.go
@@ -28,8 +28,8 @@ import (
 var contextListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"l"},
-	Short:   "list all the contexts",
-	Long:    `use to list all the contexts on the server`,
+	Short:   "List all contexts",
+	Long:    `Lists all contexts and the nodes assigned to the contexts. Per context it shows the master (responsible for replicating events) and the coordinator (responsible for rebalancing).`,
 	Run:     listContexts,
 }
 

--- a/cmd/context_register.go
+++ b/cmd/context_register.go
@@ -67,6 +67,8 @@ func init() {
 	contextRegisterCmd.Flags().StringSliceVarP(&activeBackup, "activeBackup", "a", []string{}, "[Optional - Enterprise Edition only] active backup member nodes for context")
 	contextRegisterCmd.Flags().StringSliceVarP(&passiveBackup, "passiveBackup", "p", []string{}, "[Optional - Enterprise Edition only] passive backup member nodes for context")
 	contextRegisterCmd.Flags().StringSliceVarP(&messagingOnly, "messagingOnly", "m", []string{}, "[Optional - Enterprise Edition only] messaging-only member nodes for context")
+	// required flags
+	contextRegisterCmd.MarkFlagRequired("context")
 }
 
 func createContext(cmd *cobra.Command, args []string) {

--- a/cmd/context_register.go
+++ b/cmd/context_register.go
@@ -54,15 +54,15 @@ type contextNode struct {
 var contextRegisterCmd = &cobra.Command{
 	Use:     "register",
 	Aliases: []string{"r"},
-	Short:   "Register a context",
-	Long:    `register a context on axonserver`,
+	Short:   "Creates a new context",
+	Long:    `Creates a new context, with the specified nodes assigned to it. If you do not specify nodes, all nodes will be assigned to the context.`,
 	Run:     createContext,
 }
 
 func init() {
 	contextCmd.AddCommand(contextRegisterCmd)
 
-	contextRegisterCmd.Flags().StringVarP(&contextRegister, "context", "c", "", "Name of the context")
+	contextRegisterCmd.Flags().StringVarP(&contextRegister, "context", "c", "", "*Name of the context")
 	contextRegisterCmd.Flags().StringSliceVarP(&nodes, "nodes", "n", []string{}, "[Enterprise Edition only] primary member nodes for context")
 	contextRegisterCmd.Flags().StringSliceVarP(&activeBackup, "activeBackup", "a", []string{}, "[Optional - Enterprise Edition only] active backup member nodes for context")
 	contextRegisterCmd.Flags().StringSliceVarP(&passiveBackup, "passiveBackup", "p", []string{}, "[Optional - Enterprise Edition only] passive backup member nodes for context")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,9 +55,9 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is axonserver-cli.yaml)")
 
-	rootCmd.PersistentFlags().StringVarP(&server, "server", "S", "http://localhost:8024", "URL of AxonServer")
+	rootCmd.PersistentFlags().StringVarP(&server, "server", "S", "http://localhost:8024", "Server to send command to")
 	viper.BindPFlag("server", rootCmd.PersistentFlags().Lookup("server"))
-	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "Authentication Token")
+	rootCmd.PersistentFlags().StringVarP(&token, "access-token", "t", "", "[Optional] Access token to authenticate at server")
 	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
 
 	rootCmd.Version = "1.0"

--- a/cmd/user_delete.go
+++ b/cmd/user_delete.go
@@ -33,14 +33,14 @@ var (
 var userDeleteCmd = &cobra.Command{
 	Use:     "delete",
 	Aliases: []string{"d"},
-	Short:   "Remove a user",
-	Long:    `remove a user from axonserver`,
+	Short:   "Remove the user",
+	Long:    `Deletes the specified user from axonserver.`,
 	Run:     deleteUser,
 }
 
 func init() {
 	userCmd.AddCommand(userDeleteCmd)
-	userDeleteCmd.Flags().StringVarP(&usernameDelete, "username", "u", "", "user username")
+	userDeleteCmd.Flags().StringVarP(&usernameDelete, "username", "u", "", "*user username")
 	// required flags
 	userDeleteCmd.MarkFlagRequired("username")
 }

--- a/cmd/user_delete.go
+++ b/cmd/user_delete.go
@@ -41,6 +41,8 @@ var userDeleteCmd = &cobra.Command{
 func init() {
 	userCmd.AddCommand(userDeleteCmd)
 	userDeleteCmd.Flags().StringVarP(&usernameDelete, "username", "u", "", "user username")
+	// required flags
+	userDeleteCmd.MarkFlagRequired("username")
 }
 
 func deleteUser(cmd *cobra.Command, args []string) {

--- a/cmd/user_list.go
+++ b/cmd/user_list.go
@@ -28,8 +28,8 @@ import (
 var userListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"l"},
-	Short:   "list all the users",
-	Long:    `use to list all the users on the server`,
+	Short:   "List all users",
+	Long:    `Returns a list of all registered users and their roles.`,
 	Run:     listUsers,
 }
 

--- a/cmd/user_register.go
+++ b/cmd/user_register.go
@@ -52,6 +52,8 @@ func init() {
 	userRegisterCmd.Flags().StringVarP(&usernameRegister, "username", "u", "", "user username")
 	userRegisterCmd.Flags().StringVarP(&password, "password", "p", "", "user password")
 	userRegisterCmd.Flags().StringSliceVarP(&roles, "roles", "r", []string{}, "user roles")
+	// required flags
+	userRegisterCmd.MarkFlagRequired("username")
 }
 
 func registerUser(cmd *cobra.Command, args []string) {

--- a/cmd/user_register.go
+++ b/cmd/user_register.go
@@ -42,16 +42,17 @@ var userRegisterCmd = &cobra.Command{
 	Use:     "register",
 	Aliases: []string{"r"},
 	Short:   "Register a user",
-	Long:    `register a user to be used on axonserver`,
+	Long:    `Registers a user with specified roles. If no roles are specified, Axon Server registers the user with READ role. Specify multiple roles by giving a comma separated list (without spaces), e.g. READ,ADMIN.
+If you do not specify a password with the -p option, the command line interface will prompt you for one.`,
 	Run:     registerUser,
 }
 
 func init() {
 	userCmd.AddCommand(userRegisterCmd)
 
-	userRegisterCmd.Flags().StringVarP(&usernameRegister, "username", "u", "", "user username")
-	userRegisterCmd.Flags().StringVarP(&password, "password", "p", "", "user password")
-	userRegisterCmd.Flags().StringSliceVarP(&roles, "roles", "r", []string{}, "user roles")
+	userRegisterCmd.Flags().StringVarP(&usernameRegister, "username", "u", "", "*Username")
+	userRegisterCmd.Flags().StringVarP(&password, "password", "p", "", "[Optional] Password for the user")
+	userRegisterCmd.Flags().StringSliceVarP(&roles, "roles", "r", []string{}, "[Optional] roles for the user")
 	// required flags
 	userRegisterCmd.MarkFlagRequired("username")
 }


### PR DESCRIPTION
Example output:

```
$ ./axon-server-cli.exe context register
Using config file: C:\Users\Domin\IdeaProjects\axon-server-cli\axonserver-cli.yaml
Error: required flag(s) "context" not set
Usage:
  axon-server-cli context register [flags]

Aliases:
  register, r

Flags:
  -a, --activeBackup strings    [Optional - Enterprise Edition only] active backup member nodes for context
  -c, --context string          Name of the context
  -h, --help                    help for register
  -m, --messagingOnly strings   [Optional - Enterprise Edition only] messaging-only member nodes for context
  -n, --nodes strings           [Enterprise Edition only] primary member nodes for context
  -p, --passiveBackup strings   [Optional - Enterprise Edition only] passive backup member nodes for context

Global Flags:
      --config string   config file (default is axonserver-cli.yaml)
  -S, --server string   URL of AxonServer (default "http://localhost:8024")
  -t, --token string    Authentication Token

required flag(s) "context" not set

```

This PR closes #20 .