### PR TITLE
add-node-to-context and delete-node-from-context commands added

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For the [Axon Server Standard edition](https://axoniq.io/product-overview/axon-s
 * [x] contexts
 * [x] register-context
 * [x] delete-context
-* [ ] add-node-to-context
-* [ ] delete-node-from-context
+* [x] add-node-to-context
+* [x] delete-node-from-context
 
 The option `-S` with the url to the Axon Server is optional, if it is omitted it defaults to [http://localhost:8024](http://localhost:8024/).
 

--- a/cmd/context_node.go
+++ b/cmd/context_node.go
@@ -1,0 +1,31 @@
+/*
+Copyright © 2020 Lucas Campos <lucas.campos@axoniq.io>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var contextNodeCmd = &cobra.Command{
+	Use:     "node",
+	Aliases: []string{"n"},
+	Short:   "Commands related to contexts' nodes",
+	Long:    `This is the command related to nodes related to a context`,
+}
+
+func init() {
+	contextCmd.AddCommand(contextNodeCmd)
+}

--- a/cmd/context_node_add.go
+++ b/cmd/context_node_add.go
@@ -1,0 +1,64 @@
+/*
+Copyright © 2020 Lucas Campos <lucas.campos@axoniq.io>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"axon-server-cli/httpwrapper"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// contextNodeDeleteCmd represents the DeleteNodeFromContext command
+var contextNodeAddCmd = &cobra.Command{
+	Use:     "add",
+	Aliases: []string{"a"},
+	Short:   "Add a node to a context",
+	Long:    `Adds a node with an optional role to the specified context.`,
+	Run:     addNodeToContext,
+}
+
+func init() {
+	contextNodeCmd.AddCommand(contextNodeAddCmd)
+	contextNodeAddCmd.Flags().StringP("context", "c", "", "*Name of the context")
+	contextNodeAddCmd.Flags().StringP("node", "n", "", "*Name of the node")
+	contextNodeAddCmd.Flags().StringP("role", "r", "", "Role of the node (PRIMARY, MESSAGING_ONLY, ACTIVE_BACKUP, PASSIVE_BACKUP)")
+	// required flags
+	contextNodeAddCmd.MarkFlagRequired("context")
+	contextNodeAddCmd.MarkFlagRequired("node")
+}
+
+func addNodeToContext(cmd *cobra.Command, args []string) {
+	contextName, _ := cmd.Flags().GetString("context")
+	nodeName, _ := cmd.Flags().GetString("node")
+	nodeRole, _ := cmd.Flags().GetString("role")
+
+	url := buildContextNodeAddURL(contextName, nodeName, nodeRole)
+	log.Printf("calling: %s\n", url)
+
+	responseBody := httpwrapper.POST(url, nil)
+	fmt.Printf("%s\n", responseBody)
+}
+
+func buildContextNodeAddURL(contextName string, nodeName string, nodeRole string) string {
+	url := fmt.Sprintf("%s/v1/context/%s/%s", viper.GetString("server"), contextName, nodeName)
+	if len(nodeRole) > 0 {
+		url += "?role=" + nodeRole
+	}
+	return url
+}

--- a/cmd/context_node_delete.go
+++ b/cmd/context_node_delete.go
@@ -1,0 +1,64 @@
+/*
+Copyright © 2020 Lucas Campos <lucas.campos@axoniq.io>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"axon-server-cli/httpwrapper"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// contextNodeDeleteCmd represents the DeleteNodeFromContext command
+var contextNodeDeleteCmd = &cobra.Command{
+	Use:     "delete",
+	Aliases: []string{"d"},
+	Short:   "Deletes the node from the context",
+	Long:    `Deletes the node with name from the specified context.`,
+	Run:     deleteNodeFromContext,
+}
+
+func init() {
+	contextNodeCmd.AddCommand(contextNodeDeleteCmd)
+	contextNodeDeleteCmd.Flags().StringP("context", "c", "", "*Name of the context")
+	contextNodeDeleteCmd.Flags().StringP("node", "n", "", "*Name of the node")
+	contextNodeDeleteCmd.Flags().BoolP("preserve-event-store", "p", false, "[Optional - Enterprise Edition only] keep event store contents")
+	// required flags
+	contextNodeDeleteCmd.MarkFlagRequired("context")
+	contextNodeDeleteCmd.MarkFlagRequired("node")
+}
+
+func deleteNodeFromContext(cmd *cobra.Command, args []string) {
+	contextName, _ := cmd.Flags().GetString("context")
+	nodeName, _ := cmd.Flags().GetString("node")
+	preserveEventStore, _ := cmd.Flags().GetBool("preserve-event-store")
+
+	url := buildContextNodeDeleteURL(contextName, nodeName, preserveEventStore)
+	log.Printf("calling: %s\n", url)
+
+	responseBody := httpwrapper.DELETE(url)
+	fmt.Printf("%s\n", responseBody)
+}
+
+func buildContextNodeDeleteURL(contextName string, nodeName string, preserveEventStore bool) string {
+	url := fmt.Sprintf("%s/v1/context/%s/%s", viper.GetString("server"), contextName, nodeName)
+	if preserveEventStore {
+		url += "?preserveEventStore=true"
+	}
+	return url
+}


### PR DESCRIPTION
`axon-server-cli context node add -h` and `axon-server-cli context node delete -h` added.

```
Adds a node with an optional role to the specified context.

Usage:
  axon-server-cli context node add [flags]

Aliases:
  add, a

Flags:
  -c, --context string   *Name of the context
  -h, --help             help for add
  -n, --node string      *Name of the node
  -r, --role string      Role of the node (PRIMARY, MESSAGING_ONLY, ACTIVE_BACKUP, PASSIVE_BACKUP)

Global Flags:
  -t, --access-token string   [Optional] Access token to authenticate at server
      --config string         config file (default is axonserver-cli.yaml)
  -S, --server string         Server to send command to (default "http://localhost:8024")
```

```
Deletes the node with name from the specified context.

Usage:
  axon-server-cli context node delete [flags]

Aliases:
  delete, d

Flags:
  -c, --context string         *Name of the context
  -h, --help                   help for delete
  -n, --node string            *Name of the node
  -p, --preserve-event-store   [Optional - Enterprise Edition only] keep event store contents

Global Flags:
  -t, --access-token string   [Optional] Access token to authenticate at server
      --config string         config file (default is axonserver-cli.yaml)
  -S, --server string         Server to send command to (default "http://localhost:8024")
```