### PR TITLE
Added missing token flag for application register

### DIFF
--- a/cmd/application_register.go
+++ b/cmd/application_register.go
@@ -42,7 +42,7 @@ var applicationRegisterCmd = &cobra.Command{
 	Use:     "register",
 	Aliases: []string{"r"},
 	Short:   "Register an application",
-	Long: `Registers an application with specified name. Roles is a comma seperated list of roles per context, where a role per context is the combination of @, e.g. READ@context1,WRITE@context2. If you do not specify the context for the role it will be for context default.
+	Long: `Registers an application with specified name. Roles is a comma separated list of roles per context, where a role per context is the combination of @, e.g. READ@context1,WRITE@context2. If you do not specify the context for the role it will be for context default.
 	If you omit the -T option, Axon Server will generate a unique token for you. Applications must use this token to access Axon Server. Note that this token is only returned once, you will not be able to retrieve this token later.`,
 	Run: registerApplication,
 }


### PR DESCRIPTION
```
Registers an application with specified name. Roles is a comma separated list of roles per context, where a role per context is the combination of @, e.g. READ@context1,WRITE@context2. If you do not specify the context for the role it will be for context default.
        If you omit the -T option, Axon Server will generate a unique token for you. Applications must use this token to access Axon Server. Note that this token is only returned once, you will not be able to retrieve this token later.

Usage:
  axon-server-cli application register [flags]

Aliases:
  register, r

Flags:
  -d, --description string   [Optional] Description of the application
  -h, --help                 help for register
  -a, --name string          *Name of the application
  -r, --roles strings        Roles for the application, use role@context
  -T, --token string         [Optional] Use this token for the app

Global Flags:
  -t, --access-token string   [Optional] Access token to authenticate at server
      --config string         config file (default is axonserver-cli.yaml)
  -S, --server string         Server to send command to (default "http://localhost:8024")
```